### PR TITLE
feat(github_actions_dart): add runsOn config for workflow job runners

### DIFF
--- a/bricks/github_actions_dart/CHANGELOG.md
+++ b/bricks/github_actions_dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.0
+
+- Added the ability to set the runner to use for workflow jobs by adding the `runsOn` variable.
+
 ## 4.2.0
 
 - Added the ability to preserve specific workflow files by adding them to the `preserve` variable.

--- a/bricks/github_actions_dart/README.md
+++ b/bricks/github_actions_dart/README.md
@@ -39,17 +39,20 @@ When running `mason make github_actions_dart`, you can configure global options:
 
 - **`clearOldWorkflows`**: When enabled, automatically deletes workflow files for packages that no longer exist or special files that shouldn't be generated. Files listed in `preserve` will always be kept.
 
+- **`runsOn`**: The runner to use for workflow jobs (e.g., `ubuntu-latest`, `ubuntu-22.04`). Can be overridden per-package in `actions_config.yaml`. Defaults to `ubuntu-latest`.
+
 ## Individual Package Specifications
 
 You can override properties for individual packages. They should be added to a `actions_config.yaml` file in the same directory as the `pubspec.yaml`.
 
-| Parameter             | Type            | Default                              | Description                                                                                              |
-| --------------------- | --------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------- |
-| `coverage_exclude`    | List of Strings | [ ]                                  | Glob patterns to match file names that should be excluded from code coverage (ie `**/*.g.dart`).         |
-| `analyze_directories` | List of Strings | ["lib", "test", "routes", "bin"]*   | Directories that should be analyzed. Only includes directories that exist.                                |
-| `format_directories`  | List of Strings | ["lib", "test", "routes", "bin"]*   | Directories that should be checked for formatting. Only includes directories that exist.                  |
-| `report_on`           | List of Strings | ["lib", "routes", "bin"]*            | Directories that should be reported in coverage reports. Only includes directories that exist.          |
-| `minimum_coverage`    | int             | 100             | The lowest coverage threshold considered passing.                                                        |
-| `check_licenses`      | boolean         | false           | If true, will generate a job for checking the licenses of this package to make sure they are permissive. |
-| `run_bloc_lint`       | boolean         | false           | If true, will run bloc lint on this package.                                                             |
-| `run_tests`           | boolean         | true            | If false, will skip running tests and code coverage checks for this package.                             |
+| Parameter             | Type            | Default                            | Description                                                                                                  |
+| --------------------- | --------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `coverage_exclude`    | List of Strings | [ ]                                | Glob patterns to match file names that should be excluded from code coverage (ie `**/*.g.dart`).             |
+| `analyze_directories` | List of Strings | ["lib", "test", "routes", "bin"]\* | Directories that should be analyzed. Only includes directories that exist.                                   |
+| `format_directories`  | List of Strings | ["lib", "test", "routes", "bin"]\* | Directories that should be checked for formatting. Only includes directories that exist.                     |
+| `report_on`           | List of Strings | ["lib", "routes", "bin"]\*         | Directories that should be reported in coverage reports. Only includes directories that exist.               |
+| `minimum_coverage`    | int             | 100                                | The lowest coverage threshold considered passing.                                                            |
+| `check_licenses`      | boolean         | false                              | If true, will generate a job for checking the licenses of this package to make sure they are permissive.     |
+| `run_bloc_lint`       | boolean         | false                              | If true, will run bloc lint on this package.                                                                 |
+| `run_tests`           | boolean         | true                               | If false, will skip running tests and code coverage checks for this package.                                 |
+| `runs_on`             | string          | ubuntu-latest                      | The runner to use for this package's workflow (e.g., ubuntu-22.04, macos-latest). Overrides global `runsOn`. |

--- a/bricks/github_actions_dart/__brick__/.github/workflows/{{#jobs}}{{{name}}}.yaml{{/jobs}}
+++ b/bricks/github_actions_dart/__brick__/.github/workflows/{{#jobs}}{{{name}}}.yaml{{/jobs}}
@@ -29,7 +29,7 @@ jobs:
       run:
         working-directory: {{{jobs.packageDir}}}
 
-    runs-on: ubuntu-latest
+    runs-on: {{{jobs.runsOn}}}
 
     steps:
       - name: 📚 Git Checkout

--- a/bricks/github_actions_dart/brick.yaml
+++ b/bricks/github_actions_dart/brick.yaml
@@ -1,7 +1,7 @@
 name: github_actions_dart
 description: A brick that simplifies generating Github actions for Dart/Flutter monorepos
 repository: https://github.com/mtwichel/mason_bricks/tree/main/bricks/github_actions_dart
-version: 4.2.0
+version: 4.3.0
 vars:
   exclude:
     type: string
@@ -15,6 +15,10 @@ vars:
     type: number
     description: The minimum coverage required for a package to be considered passing.
     default: 100
+  runsOn:
+    type: string
+    description: The runner to use for workflow jobs (e.g., ubuntu-latest, ubuntu-22.04).
+    default: ubuntu-latest
   flutterVersion:
     type: string
     description: The version of Flutter to use.

--- a/bricks/github_actions_dart/hooks/pre_gen.dart
+++ b/bricks/github_actions_dart/hooks/pre_gen.dart
@@ -138,6 +138,10 @@ Future<void> run(HookContext context) async {
         config: config,
       ),
       checkLicenses: (config['check_licenses'] as bool?) ?? false,
+      runsOn: getRunsOn(
+        context: context,
+        config: config,
+      ),
     );
   });
 
@@ -397,6 +401,25 @@ bool getRunTests({
   return testDir.existsSync();
 }
 
+String getRunsOn({
+  required HookContext context,
+  required Map<String, dynamic> config,
+}) {
+  // Per-package config takes precedence
+  final configRunsOn = config['runs_on'];
+  if (configRunsOn is String && configRunsOn.isNotEmpty) {
+    return configRunsOn;
+  }
+
+  // Global config (variables passed in)
+  final globalRunsOn = context.vars['runsOn'];
+  if (globalRunsOn is String && globalRunsOn.isNotEmpty) {
+    return globalRunsOn;
+  }
+
+  return 'ubuntu-latest';
+}
+
 class Job {
   const Job({
     required this.usesFlutter,
@@ -412,6 +435,7 @@ class Job {
     required this.checkLicenses,
     required this.runBlocLint,
     required this.runTests,
+    required this.runsOn,
   });
 
   Map<String, dynamic> toJson() => {
@@ -433,6 +457,7 @@ class Job {
         'runBlocLint': runBlocLint,
         'runTests': runTests,
         'hasMinimumCoverage': hasMinimumCoverage,
+        'runsOn': runsOn,
       };
 
   final bool usesFlutter;
@@ -448,6 +473,7 @@ class Job {
   final bool checkLicenses;
   final bool runBlocLint;
   final bool runTests;
+  final String runsOn;
 
   bool get hasAnalyzeDirectories => analyzeDirectories.isNotEmpty;
   bool get hasFormatDirectories => formatDirectories.isNotEmpty;


### PR DESCRIPTION
## Summary
Add configurable `runsOn` for workflow job runners with three levels of configuration:

1. **Per-package config** – `runs_on` in `actions_config.yaml` (highest precedence)
2. **Global config** – `runsOn` variable passed to `mason make`
3. **Default** – `ubuntu-latest` if neither is provided

## Changes
- Add `runsOn` to brick.yaml with default `ubuntu-latest`
- Add `getRunsOn()` in pre_gen.dart for config resolution
- Update workflow template to use `{{{jobs.runsOn}}}`
- Document in README (global + per-package table)
- Bump version to 4.3.0 and update CHANGELOG

Made with [Cursor](https://cursor.com)