### PR TITLE
feat(github_actions_dart): add optional setup step for workflows

### DIFF
--- a/bricks/github_actions_dart/CHANGELOG.md
+++ b/bricks/github_actions_dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.4.0
+
+- Added optional inline setup step (name + run) that runs after checkout and before Flutter/Dart. Configure globally via `setup_step_name` and `setup_step_run` in `workflows_config.json`, or per-package via `setup_step` (object with `name` and `run`) or `setup_step_name` / `setup_step_run` in `actions_config.yaml`. Use for runner-level setup (e.g. installing system packages like `xz-utils`).
+
 ## 4.3.1
 
 - Fixed issue where the `runsOn` variable was not being set in the `workflows_config.json` file.

--- a/bricks/github_actions_dart/README.md
+++ b/bricks/github_actions_dart/README.md
@@ -41,6 +41,8 @@ When running `mason make github_actions_dart`, you can configure global options:
 
 - **`runsOn`**: The runner to use for workflow jobs (e.g., `ubuntu-latest`, `ubuntu-22.04`). Can be overridden per-package in `actions_config.yaml`. Defaults to `ubuntu-latest`.
 
+- **`setup_step_name`** and **`setup_step_run`**: Optional. If `setup_step_run` is non-empty, a setup step runs immediately after checkout and before Flutter/Dart (e.g. to install system deps like `xz-utils`). Use `\n` for newlines in the run body when setting via `workflows_config.json`. Can be overridden per-package in `actions_config.yaml`. Defaults empty (no step).
+
 ## Individual Package Specifications
 
 You can override properties for individual packages. They should be added to a `actions_config.yaml` file in the same directory as the `pubspec.yaml`.
@@ -56,3 +58,4 @@ You can override properties for individual packages. They should be added to a `
 | `run_bloc_lint`       | boolean         | false                              | If true, will run bloc lint on this package.                                                                 |
 | `run_tests`           | boolean         | true                               | If false, will skip running tests and code coverage checks for this package.                                 |
 | `runs_on`             | string          | ubuntu-latest                      | The runner to use for this package's workflow (e.g., ubuntu-22.04, macos-latest). Overrides global `runsOn`. |
+| `setup_step`          | object          | —                                  | Optional. Object with `name` and `run` for a setup step (runs after checkout, before Flutter/Dart). YAML multiline for `run` is supported. Overrides global; empty or omit = use global or no step. Alternatively use `setup_step_name` and `setup_step_run`. |

--- a/bricks/github_actions_dart/__brick__/.github/workflows/{{#jobs}}{{{name}}}.yaml{{/jobs}}
+++ b/bricks/github_actions_dart/__brick__/.github/workflows/{{#jobs}}{{{name}}}.yaml{{/jobs}}
@@ -35,7 +35,13 @@ jobs:
       - name: 📚 Git Checkout
         uses: actions/checkout@v6
 
-      {{#jobs.usesFlutter}}- name: 🐦 Setup Flutter
+      {{#jobs.hasSetupStep}}- name: {{{jobs.setupStepName}}}
+        run: |
+{{{jobs.setupStepRun}}}
+
+        working-directory: .
+
+      {{/jobs.hasSetupStep}}{{#jobs.usesFlutter}}- name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:
           flutter-version: {{{flutterVersion}}}

--- a/bricks/github_actions_dart/__brick__/.github/workflows_config.json
+++ b/bricks/github_actions_dart/__brick__/.github/workflows_config.json
@@ -14,5 +14,7 @@
   "mainJobName": "{{{mainJobName}}}",
   "licenseCheckJobName": "{{{licenseCheckJobName}}}",
   "preserve": "{{{preserve}}}",
-  "runsOn": "{{{runsOn}}}"
+  "runsOn": "{{{runsOn}}}",
+  "setup_step_name": "{{{setup_step_name}}}",
+  "setup_step_run": "{{{setup_step_run}}}"
 }

--- a/bricks/github_actions_dart/brick.yaml
+++ b/bricks/github_actions_dart/brick.yaml
@@ -1,7 +1,7 @@
 name: github_actions_dart
 description: A brick that simplifies generating Github actions for Dart/Flutter monorepos
 repository: https://github.com/mtwichel/mason_bricks/tree/main/bricks/github_actions_dart
-version: 4.3.1
+version: 4.4.0
 vars:
   exclude:
     type: string
@@ -74,3 +74,11 @@ vars:
     type: string
     default: license_check
     description: The name of the job where licenses are checked for permissiveness.
+  setup_step_name:
+    type: string
+    description: Optional name for a setup step that runs before other steps (e.g. install system deps). Use with setup_step_run; use \n for newlines in run when setting via config file.
+    default: ""
+  setup_step_run:
+    type: string
+    description: Optional run script body for a setup step that runs before other steps (e.g. install system deps). Use \n for newlines when setting via config file.
+    default: ""

--- a/bricks/github_actions_dart/hooks/pre_gen.dart
+++ b/bricks/github_actions_dart/hooks/pre_gen.dart
@@ -42,6 +42,7 @@ Future<void> run(HookContext context) async {
 
     final config =
         readConfigFile(logger: context.logger, path: package.packageDir);
+    final setupStep = getSetupStep(context: context, config: config);
 
     final rawConfigCoverageExclude = config['coverage_exclude'];
     final configCoverageExclude = switch (rawConfigCoverageExclude) {
@@ -142,6 +143,8 @@ Future<void> run(HookContext context) async {
         context: context,
         config: config,
       ),
+      setupStepName: setupStep.name,
+      setupStepRun: _indentRunBody(setupStep.run),
     );
   });
 
@@ -420,6 +423,73 @@ String getRunsOn({
   return 'ubuntu-latest';
 }
 
+({String name, String run}) getSetupStep({
+  required HookContext context,
+  required Map<String, dynamic> config,
+}) {
+  const defaultName = 'Setup';
+
+  String stringFromDynamic(dynamic v) {
+    if (v == null) return '';
+    if (v is String) return v;
+    // Values from readConfigFile nested maps can be YamlScalar
+    if (v is YamlNode) return v.value?.toString() ?? '';
+    return v.toString();
+  }
+
+  // Per-package name override: use with global run when package sets only a name
+  var packageNameOverride = '';
+
+  // Per-package: setup_step (map with name and run) or setup_step_name / setup_step_run
+  final setupStepMap = config['setup_step'];
+  if (setupStepMap is Map) {
+    final run = stringFromDynamic(setupStepMap['run']).trim();
+    final name = stringFromDynamic(setupStepMap['name']).trim();
+    if (run.isNotEmpty) {
+      return (name: name.isEmpty ? defaultName : name, run: run);
+    }
+    if (name.isNotEmpty) packageNameOverride = name;
+  }
+  final configName = config['setup_step_name'];
+  final configRun = config['setup_step_run'];
+  if (configName is String || configRun is String) {
+    final run = stringFromDynamic(configRun).trim();
+    if (run.isNotEmpty) {
+      final name = stringFromDynamic(configName).trim();
+      return (name: name.isEmpty ? defaultName : name, run: run);
+    }
+    final name = stringFromDynamic(configName).trim();
+    if (name.isNotEmpty) packageNameOverride = name;
+  }
+
+  // Global config (variables passed in). Respect per-package name override when using global run.
+  final globalName = context.vars['setup_step_name'];
+  final globalRun = context.vars['setup_step_run'];
+  if (globalName is String || globalRun is String) {
+    final run = stringFromDynamic(globalRun).trim();
+    if (run.isNotEmpty) {
+      final name = packageNameOverride.isNotEmpty
+          ? packageNameOverride
+          : stringFromDynamic(globalName).trim();
+      return (name: name.isEmpty ? defaultName : name, run: run);
+    }
+  }
+
+  return (name: '', run: '');
+}
+
+/// Indents each line of the run body so the generated workflow YAML is valid under `run: |`.
+/// Blank lines (empty or whitespace-only) are left empty. Non-blank lines keep their original
+/// content including leading whitespace, so shell script indentation (if/for blocks, etc.) is preserved.
+String _indentRunBody(String run) {
+  if (run.isEmpty) return run;
+  const indent = '          '; // 10 spaces to align under run: |
+  return run.split('\n').map((line) {
+    final isBlank = line.trim().isEmpty;
+    return isBlank ? '' : '$indent$line';
+  }).join('\n');
+}
+
 class Job {
   const Job({
     required this.usesFlutter,
@@ -436,6 +506,8 @@ class Job {
     required this.runBlocLint,
     required this.runTests,
     required this.runsOn,
+    required this.setupStepName,
+    required this.setupStepRun,
   });
 
   Map<String, dynamic> toJson() => {
@@ -458,6 +530,9 @@ class Job {
         'runTests': runTests,
         'hasMinimumCoverage': hasMinimumCoverage,
         'runsOn': runsOn,
+        'setupStepName': setupStepName,
+        'setupStepRun': setupStepRun,
+        'hasSetupStep': hasSetupStep,
       };
 
   final bool usesFlutter;
@@ -474,11 +549,14 @@ class Job {
   final bool runBlocLint;
   final bool runTests;
   final String runsOn;
+  final String setupStepName;
+  final String setupStepRun;
 
   bool get hasAnalyzeDirectories => analyzeDirectories.isNotEmpty;
   bool get hasFormatDirectories => formatDirectories.isNotEmpty;
   bool get hasReportOnDirectories => reportOnDirectories.isNotEmpty;
   bool get hasMinimumCoverage => minimumCoverage > 0;
+  bool get hasSetupStep => setupStepRun.isNotEmpty;
 }
 
 class Package {


### PR DESCRIPTION
- Introduced `setup_step_name` and `setup_step_run` for defining a setup step that runs after checkout and before other steps.
- Configurable globally in `workflows_config.json` or per-package in `actions_config.yaml`.
- Updated README and CHANGELOG to reflect new features.